### PR TITLE
Show rx is as a dependency in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Yet another RxJS library for React :)
 Create **smart components** — also known as container components — using RxJS observables.
 
 ```
-npm install --save react-rx-component
+npm install --save react-rx-component rx
 ```
 
 ## Don't `setState()` — transform props


### PR DESCRIPTION
I tried using redux-rx but didn't have rx installed yet so it failed, I think this makes it a bit clearer that the user is expected to install it. 